### PR TITLE
Readme formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-**================ VEEAM-Backup-Recovery-jobs ================**
+# VEEAM-Backup-Recovery-jobs
 
 This template use the VEEAM Backup & Replication PowerShell Cmdlets to discover and manage VEEAM Backup jobs, Veeam BackupSync, Veeam Tape Job, Veeam Endpoint Backup Jobs, All Repositories and Veeam Services.
 
@@ -12,15 +12,15 @@ Then, each request imports the xml to retrieve the information.<br />
 Why? Because the execution of this command can take between 30 seconds and more than 3 minutes (depending on the history and the number of tasks) and I end up with several scripts running for a certain time and the execution is in timeout.
 <br /><br />
 
-**-------- Items --------**
+## Items
 
   - Number of tasks jobs<br />
   - Number of running jobs<br />
   - Result Export Xml Veeam<br />
 
-**-------- Discovery Jobs --------**
+## Discovery Jobs
 
-**1. Veeam Jobs :** <br />
+### 1. Veeam Jobs:
   - Result of each jobs<br />
   - Execution status for each jobs<br />
   - Number of VMs Failed in each jobs<br />
@@ -31,11 +31,11 @@ Why? Because the execution of this command can take between 30 seconds and more 
   - Size excluded in each jobs (disabled by default)<br />
   - Next run time of each jobs<br />
 
-**2. Veeam Tape Jobs :**<br />
+### 2. Veeam Tape Jobs:
   - Result of each jobs<br />
   - Execution status for each jobs<br />
 
-**3. Veeam BackupSync Jobs :**<br />
+### 3. Veeam BackupSync Jobs:
   - Result of each jobs<br />
   - Execution status for each jobs<br />
   - Number of VMs Failed in each jobs<br />
@@ -45,59 +45,59 @@ Why? Because the execution of this command can take between 30 seconds and more 
   - Size included in each jobs (disabled by default)<br />
   - Size excluded in each jobs (disabled by default)<br />
 
-**4. Veeam Jobs Endpoint Backup:**<br />
+### 4. Veeam Jobs Endpoint Backup:
   - Result of each jobs<br />
   - Execution status for each jobs<br />
   - Next run time of each jobs<br />
 
-**5. Veeam Repository :**<br />
+### 5. Veeam Repository:
   - Remaining space in repository for each repo<br />
   - Total space in repository for each repo<br /><br />
 
-**-------- Discovery Jobs By VMs --------**
+## Discovery Jobs By VMs
 
-**1. VEEAM Backup By VMs :**
+### 1. VEEAM Backup By VMs:
   - Result of each VMs in each Jobs
-  
-**2. VEEAM BackupSync By VMs :**
+
+### 2. VEEAM BackupSync By VMs:
   - Result of each VMs in each Jobs
 <br />
 
-**-------- Triggers --------**
+## Triggers
 <br><br />
 [WARNING] => Export XML Veeam Error<br />
 
--------- Discovery Veeam Jobs --------<br />
+### Discovery Veeam Jobs
 [HIGH] => Job has FAILED <br />
 [AVERAGE] => Job has completed with warning
 [HIGH] => Job is still running (8 hours)<br />
 [WARNING] => Backup Veeam data recovery problem
 
--------- Discovery Veeam Tape Jobs --------<br />
+### Discovery Veeam Tape Jobs
 [HIGH] => Job has FAILED <br />
 [AVERAGE] => Job has completed with warning<br />
 [HIGH] => Job is still running (8 hours)<br />
 [INFORMATION] => No data recovery for 24 hours<br />
 
--------- Discovery Veeam BackupSync Jobs --------<br />
+### Discovery Veeam BackupSync Jobs
 [HIGH] => Job has FAILED <br />
 [AVERAGE] => Job has completed with warning<br />
 [INFORMATION] => No data recovery for 24 hours<br />
 
--------- Discovery Veeam Jobs Endpoint Agent --------<br />
+### Discovery Veeam Jobs Endpoint Agent
 [HIGH] => Job has FAILED <br />
 [AVERAGE] => Job has completed with warning<br />
 [HIGH] => Job is still running (8 hours)<br />
 [INFORMATION] => No data recovery for 24 hours<br />
 
--------- Discovery Veeam Repository --------<br />
+### Discovery Veeam Repository
 [HIGH] => Less than 2Gb remaining on the repository
 
--------- Discovery Veeam Services --------<br />
+### Discovery Veeam Services
 [AVERAGE] => Veeam Service is down for each services<br />
 <br />
 
-**-------- Setup --------**
+## Setup
 
 1. Install the Zabbix agent on your host
 2. Copy zabbix_vbr_job.ps1 in the directory : "C:\Program Files\Zabbix Agent\scripts\" (create folder if not exist)

--- a/README.md
+++ b/README.md
@@ -66,36 +66,36 @@ Why? Because the execution of this command can take between 30 seconds and more 
 
 ## Triggers
 
-[WARNING] => Export XML Veeam Error
+- [WARNING] => Export XML Veeam Error
 
 ### Discovery Veeam Jobs
-[HIGH] => Job has FAILED
-[AVERAGE] => Job has completed with warning
-[HIGH] => Job is still running (8 hours)
-[WARNING] => Backup Veeam data recovery problem
+- [HIGH] => Job has FAILED
+- [AVERAGE] => Job has completed with warning
+- [HIGH] => Job is still running (8 hours)
+- [WARNING] => Backup Veeam data recovery problem
 
 ### Discovery Veeam Tape Jobs
-[HIGH] => Job has FAILED
-[AVERAGE] => Job has completed with warning
-[HIGH] => Job is still running (8 hours)
-[INFORMATION] => No data recovery for 24 hours
+- [HIGH] => Job has FAILED
+- [AVERAGE] => Job has completed with warning
+- [HIGH] => Job is still running (8 hours)
+- [INFORMATION] => No data recovery for 24 hours
 
 ### Discovery Veeam BackupSync Jobs
-[HIGH] => Job has FAILED
-[AVERAGE] => Job has completed with warning
-[INFORMATION] => No data recovery for 24 hours
+- [HIGH] => Job has FAILED
+- [AVERAGE] => Job has completed with warning
+- [INFORMATION] => No data recovery for 24 hours
 
 ### Discovery Veeam Jobs Endpoint Agent
-[HIGH] => Job has FAILED
-[AVERAGE] => Job has completed with warning
-[HIGH] => Job is still running (8 hours)
-[INFORMATION] => No data recovery for 24 hours
+- [HIGH] => Job has FAILED
+- [AVERAGE] => Job has completed with warning
+- [HIGH] => Job is still running (8 hours)
+- [INFORMATION] => No data recovery for 24 hours
 
 ### Discovery Veeam Repository
-[HIGH] => Less than 2Gb remaining on the repository
+- [HIGH] => Less than 2Gb remaining on the repository
 
 ### Discovery Veeam Services
-[AVERAGE] => Veeam Service is down for each services
+- [AVERAGE] => Veeam Service is down for each services
 
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -2,13 +2,14 @@
 
 This template use the VEEAM Backup & Replication PowerShell Cmdlets to discover and manage VEEAM Backup jobs, Veeam BackupSync, Veeam Tape Job, Veeam Endpoint Backup Jobs, All Repositories and Veeam Services.
 
-Work with Veeam backup & replication V7 to V9.5
-Work with Zabbix 3.X (english template only for V3.X) & 4.X
-French & English translation for the Template
+- Work with Veeam backup & replication V7 to V9.5
+- Work with Zabbix 3.X (english template only for V3.X) & 4.X
+- French & English translation for the Template
 
-Explanation of how it works :
-The "Result Export Xml Veeam" item sends a powerhell command (with nowait option) to the host to create an xml file of the result of the Get-VBRBbackupSession,Get-VBRJob, Get-VRBBackup and Get-VBREPJob commands that is stored under C:\Program Files\Zabbix Agent\scripts\TempXmlVeeam\\*.xml (variable $pathxml)
+### Explanation of how it works:
+The "Result Export Xml Veeam" item sends a powershell command (with `nowait` option) to the host to create an xml file of the result of the `Get-VBRBbackupSession`, `Get-VBRJob`, `Get-VRBBackup` and `Get-VBREPJob` commands that is stored under `C:\Program Files\Zabbix Agent\scripts\TempXmlVeeam\*.xml` (variable `$pathxml`).
 Then, each request imports the xml to retrieve the information.
+
 Why? Because the execution of this command can take between 30 seconds and more than 3 minutes (depending on the history and the number of tasks) and I end up with several scripts running for a certain time and the execution is in timeout.
 
 

--- a/README.md
+++ b/README.md
@@ -2,57 +2,57 @@
 
 This template use the VEEAM Backup & Replication PowerShell Cmdlets to discover and manage VEEAM Backup jobs, Veeam BackupSync, Veeam Tape Job, Veeam Endpoint Backup Jobs, All Repositories and Veeam Services.
 
-Work with Veeam backup & replication V7 to V9.5<br />
-Work with Zabbix 3.X (english template only for V3.X) & 4.X<br />
+Work with Veeam backup & replication V7 to V9.5
+Work with Zabbix 3.X (english template only for V3.X) & 4.X
 French & English translation for the Template
 
-Explanation of how it works :<br />
-The "Result Export Xml Veeam" item sends a powerhell command (with nowait option) to the host to create an xml file of the result of the Get-VBRBbackupSession,Get-VBRJob, Get-VRBBackup and Get-VBREPJob commands that is stored under C:\Program Files\Zabbix Agent\scripts\TempXmlVeeam\\*.xml (variable $pathxml)<br />
-Then, each request imports the xml to retrieve the information.<br />
+Explanation of how it works :
+The "Result Export Xml Veeam" item sends a powerhell command (with nowait option) to the host to create an xml file of the result of the Get-VBRBbackupSession,Get-VBRJob, Get-VRBBackup and Get-VBREPJob commands that is stored under C:\Program Files\Zabbix Agent\scripts\TempXmlVeeam\\*.xml (variable $pathxml)
+Then, each request imports the xml to retrieve the information.
 Why? Because the execution of this command can take between 30 seconds and more than 3 minutes (depending on the history and the number of tasks) and I end up with several scripts running for a certain time and the execution is in timeout.
-<br /><br />
+
 
 ## Items
 
-  - Number of tasks jobs<br />
-  - Number of running jobs<br />
-  - Result Export Xml Veeam<br />
+  - Number of tasks jobs
+  - Number of running jobs
+  - Result Export Xml Veeam
 
 ## Discovery Jobs
 
 ### 1. Veeam Jobs:
-  - Result of each jobs<br />
-  - Execution status for each jobs<br />
-  - Number of VMs Failed in each jobs<br />
-  - Number of VMs Warning in each jobs<br />
-  - Type for each jobs<br />
-  - Number of VMs in each jobs<br />
-  - Size included in each jobs (disabled by default)<br />
-  - Size excluded in each jobs (disabled by default)<br />
-  - Next run time of each jobs<br />
+  - Result of each jobs
+  - Execution status for each jobs
+  - Number of VMs Failed in each jobs
+  - Number of VMs Warning in each jobs
+  - Type for each jobs
+  - Number of VMs in each jobs
+  - Size included in each jobs (disabled by default)
+  - Size excluded in each jobs (disabled by default)
+  - Next run time of each jobs
 
 ### 2. Veeam Tape Jobs:
-  - Result of each jobs<br />
-  - Execution status for each jobs<br />
+  - Result of each jobs
+  - Execution status for each jobs
 
 ### 3. Veeam BackupSync Jobs:
-  - Result of each jobs<br />
-  - Execution status for each jobs<br />
-  - Number of VMs Failed in each jobs<br />
-  - Number of VMs Warning in each jobs<br />
-  - Type for each jobs<br />
-  - Number of VMs in each jobs<br />
-  - Size included in each jobs (disabled by default)<br />
-  - Size excluded in each jobs (disabled by default)<br />
+  - Result of each jobs
+  - Execution status for each jobs
+  - Number of VMs Failed in each jobs
+  - Number of VMs Warning in each jobs
+  - Type for each jobs
+  - Number of VMs in each jobs
+  - Size included in each jobs (disabled by default)
+  - Size excluded in each jobs (disabled by default)
 
 ### 4. Veeam Jobs Endpoint Backup:
-  - Result of each jobs<br />
-  - Execution status for each jobs<br />
-  - Next run time of each jobs<br />
+  - Result of each jobs
+  - Execution status for each jobs
+  - Next run time of each jobs
 
 ### 5. Veeam Repository:
-  - Remaining space in repository for each repo<br />
-  - Total space in repository for each repo<br /><br />
+  - Remaining space in repository for each repo
+  - Total space in repository for each repo
 
 ## Discovery Jobs By VMs
 
@@ -61,62 +61,62 @@ Why? Because the execution of this command can take between 30 seconds and more 
 
 ### 2. VEEAM BackupSync By VMs:
   - Result of each VMs in each Jobs
-<br />
+
 
 ## Triggers
-<br><br />
-[WARNING] => Export XML Veeam Error<br />
+
+[WARNING] => Export XML Veeam Error
 
 ### Discovery Veeam Jobs
-[HIGH] => Job has FAILED <br />
+[HIGH] => Job has FAILED
 [AVERAGE] => Job has completed with warning
-[HIGH] => Job is still running (8 hours)<br />
+[HIGH] => Job is still running (8 hours)
 [WARNING] => Backup Veeam data recovery problem
 
 ### Discovery Veeam Tape Jobs
-[HIGH] => Job has FAILED <br />
-[AVERAGE] => Job has completed with warning<br />
-[HIGH] => Job is still running (8 hours)<br />
-[INFORMATION] => No data recovery for 24 hours<br />
+[HIGH] => Job has FAILED
+[AVERAGE] => Job has completed with warning
+[HIGH] => Job is still running (8 hours)
+[INFORMATION] => No data recovery for 24 hours
 
 ### Discovery Veeam BackupSync Jobs
-[HIGH] => Job has FAILED <br />
-[AVERAGE] => Job has completed with warning<br />
-[INFORMATION] => No data recovery for 24 hours<br />
+[HIGH] => Job has FAILED
+[AVERAGE] => Job has completed with warning
+[INFORMATION] => No data recovery for 24 hours
 
 ### Discovery Veeam Jobs Endpoint Agent
-[HIGH] => Job has FAILED <br />
-[AVERAGE] => Job has completed with warning<br />
-[HIGH] => Job is still running (8 hours)<br />
-[INFORMATION] => No data recovery for 24 hours<br />
+[HIGH] => Job has FAILED
+[AVERAGE] => Job has completed with warning
+[HIGH] => Job is still running (8 hours)
+[INFORMATION] => No data recovery for 24 hours
 
 ### Discovery Veeam Repository
 [HIGH] => Less than 2Gb remaining on the repository
 
 ### Discovery Veeam Services
-[AVERAGE] => Veeam Service is down for each services<br />
-<br />
+[AVERAGE] => Veeam Service is down for each services
+
 
 ## Setup
 
 1. Install the Zabbix agent on your host
 2. Copy zabbix_vbr_job.ps1 in the directory : "C:\Program Files\Zabbix Agent\scripts\" (create folder if not exist)
-3. Add the following line to your Zabbix agent configuration file.<br />
-EnableRemoteCommands=1 <br />
-UnsafeUserParameters=1 <br />
-ServerActive="IP or DNS Zabbix Server"<br />
-Alias=service.discovery.veeam:service.discovery<br />
+3. Add the following line to your Zabbix agent configuration file.
+EnableRemoteCommands=1
+UnsafeUserParameters=1
+ServerActive="IP or DNS Zabbix Server"
+Alias=service.discovery.veeam:service.discovery
 UserParameter=vbr[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\zabbix_vbr_job.ps1" "$1" "$2" "$3"
-4. In Zabbix : Administration, General, Regular Expression : Add a new regular expression :<br />
-Name : "Veeam"    ;     Expression type : "**TRUE**"     ;     	Expression : "Veeam.\*"<br />
-And modify regular expression "Windows service startup states for discovery" : Add : <br />
-Name : "Veeam" ; Expression type : "**FALSE**" ; Expression : "Veeam.\*"<br />
+4. In Zabbix : Administration, General, Regular Expression : Add a new regular expression :
+Name : "Veeam"    ;     Expression type : "**TRUE**"     ;     	Expression : "Veeam.\*"
+And modify regular expression "Windows service startup states for discovery" : Add :
+Name : "Veeam" ; Expression type : "**FALSE**" ; Expression : "Veeam.\*"
 5. Import TemplateVEEAM-BACKUPtrapper.xml file into Zabbix.
 6. Purge and clean Template OS Windows if is linked to the host (you can relink it after).
 7. Associate "Template VEEAM - Backup and Replication" to the host.
-8. Wait about 1h for discovery, XML file to be generated and first informations retrieves.<br><br>
+8. Wait about 1h for discovery, XML file to be generated and first informations retrieves.
 ! If you use old version (< v3) please Purge and clean "Template VEEAM-BACKUP trapper".
-<br>
-With a large or very large backup tasks history, the XML size can be more than 500 MB (so script finish in timeout) you can reduce this with this link : <br />
-https://www.veeam.com/kb1995 <br />
+
+With a large or very large backup tasks history, the XML size can be more than 500 MB (so script finish in timeout) you can reduce this with this link :
+https://www.veeam.com/kb1995
 Use first : "Changing Session history retention" and if this is not enough, "Clear old job sessions".

--- a/README.md
+++ b/README.md
@@ -111,13 +111,15 @@ Why? Because the execution of this command can take between 30 seconds and more 
     UserParameter=vbr[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\zabbix_vbr_job.ps1" "$1" "$2" "$3"
     ```
 4. In Zabbix : Administration, General, Regular Expression:
-    ```
-    Add a new regular expression:
-    Name : "Veeam"    ;     Expression type : "**TRUE**"     ;     	Expression : "Veeam.\*"
 
-    And modify regular expression "Windows service startup states for discovery" : Add :
-    Name : "Veeam" ; Expression type : "**FALSE**" ; Expression : "Veeam.\*"
-    ```
+    1. Add a new regular expression:
+        + Name: `Veeam`
+        + Expression Type: `Result is TRUE`
+        + Expression: `Veeam.*`
+    2.  Modify the "Windows Service Startup States for Discovery regex by adding a new expression:
+        + Expression Type: `Result is FALSE`
+        + Expression: `Veeam.*`
+
 5. Import TemplateVEEAM-BACKUPtrapper.xml file into Zabbix.
 6. Purge and clean Template OS Windows if is linked to the host (you can relink it after).
 7. Associate "Template VEEAM - Backup and Replication" to the host.

--- a/README.md
+++ b/README.md
@@ -101,21 +101,28 @@ Why? Because the execution of this command can take between 30 seconds and more 
 ## Setup
 
 1. Install the Zabbix agent on your host
-2. Copy zabbix_vbr_job.ps1 in the directory : "C:\Program Files\Zabbix Agent\scripts\" (create folder if not exist)
-3. Add the following line to your Zabbix agent configuration file.
-EnableRemoteCommands=1
-UnsafeUserParameters=1
-ServerActive="IP or DNS Zabbix Server"
-Alias=service.discovery.veeam:service.discovery
-UserParameter=vbr[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\zabbix_vbr_job.ps1" "$1" "$2" "$3"
-4. In Zabbix : Administration, General, Regular Expression : Add a new regular expression :
-Name : "Veeam"    ;     Expression type : "**TRUE**"     ;     	Expression : "Veeam.\*"
-And modify regular expression "Windows service startup states for discovery" : Add :
-Name : "Veeam" ; Expression type : "**FALSE**" ; Expression : "Veeam.\*"
+2. Copy `zabbix_vbr_job.ps1` in the directory : `C:\Program Files\Zabbix Agent\scripts\` (create folder if not exist)
+3. Add the following line to your Zabbix agent configuration file:
+    ```
+    EnableRemoteCommands=1
+    UnsafeUserParameters=1
+    ServerActive="IP or DNS Zabbix Server"
+    Alias=service.discovery.veeam:service.discovery
+    UserParameter=vbr[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\zabbix_vbr_job.ps1" "$1" "$2" "$3"
+    ```
+4. In Zabbix : Administration, General, Regular Expression:
+    ```
+    Add a new regular expression:
+    Name : "Veeam"    ;     Expression type : "**TRUE**"     ;     	Expression : "Veeam.\*"
+
+    And modify regular expression "Windows service startup states for discovery" : Add :
+    Name : "Veeam" ; Expression type : "**FALSE**" ; Expression : "Veeam.\*"
+    ```
 5. Import TemplateVEEAM-BACKUPtrapper.xml file into Zabbix.
 6. Purge and clean Template OS Windows if is linked to the host (you can relink it after).
 7. Associate "Template VEEAM - Backup and Replication" to the host.
 8. Wait about 1h for discovery, XML file to be generated and first informations retrieves.
+
 ! If you use old version (< v3) please Purge and clean "Template VEEAM-BACKUP trapper".
 
 With a large or very large backup tasks history, the XML size can be more than 500 MB (so script finish in timeout) you can reduce this with this link :

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This template use the VEEAM Backup & Replication PowerShell Cmdlets to discover and manage VEEAM Backup jobs, Veeam BackupSync, Veeam Tape Job, Veeam Endpoint Backup Jobs, All Repositories and Veeam Services.
 
 Work with Veeam backup & replication V7 to V9.5<br />
-Work with Zabbix 3.X (english template only for V3.X) & 4.X<br /> 
+Work with Zabbix 3.X (english template only for V3.X) & 4.X<br />
 French & English translation for the Template
 
 Explanation of how it works :<br />
@@ -69,7 +69,7 @@ Why? Because the execution of this command can take between 30 seconds and more 
 
 -------- Discovery Veeam Jobs --------<br />
 [HIGH] => Job has FAILED <br />
-[AVERAGE] => Job has completed with warning  
+[AVERAGE] => Job has completed with warning
 [HIGH] => Job is still running (8 hours)<br />
 [WARNING] => Backup Veeam data recovery problem
 
@@ -107,16 +107,16 @@ UnsafeUserParameters=1 <br />
 ServerActive="IP or DNS Zabbix Server"<br />
 Alias=service.discovery.veeam:service.discovery<br />
 UserParameter=vbr[*],powershell -NoProfile -ExecutionPolicy Bypass -File "C:\Program Files\Zabbix Agent\scripts\zabbix_vbr_job.ps1" "$1" "$2" "$3"
-4. In Zabbix : Administration, General, Regular Expression : Add a new regular expression :<br /> 
+4. In Zabbix : Administration, General, Regular Expression : Add a new regular expression :<br />
 Name : "Veeam"    ;     Expression type : "**TRUE**"     ;     	Expression : "Veeam.\*"<br />
 And modify regular expression "Windows service startup states for discovery" : Add : <br />
 Name : "Veeam" ; Expression type : "**FALSE**" ; Expression : "Veeam.\*"<br />
-5. Import TemplateVEEAM-BACKUPtrapper.xml file into Zabbix. 
+5. Import TemplateVEEAM-BACKUPtrapper.xml file into Zabbix.
 6. Purge and clean Template OS Windows if is linked to the host (you can relink it after).
 7. Associate "Template VEEAM - Backup and Replication" to the host.
 8. Wait about 1h for discovery, XML file to be generated and first informations retrieves.<br><br>
 ! If you use old version (< v3) please Purge and clean "Template VEEAM-BACKUP trapper".
 <br>
-With a large or very large backup tasks history, the XML size can be more than 500 MB (so script finish in timeout) you can reduce this with this link : <br /> 
+With a large or very large backup tasks history, the XML size can be more than 500 MB (so script finish in timeout) you can reduce this with this link : <br />
 https://www.veeam.com/kb1995 <br />
 Use first : "Changing Session history retention" and if this is not enough, "Clear old job sessions".


### PR DESCRIPTION
This PR updates the formatting of README.md to follow Markdown more closely.

Changes:
+ Removed trailing whitespace from lines
+ Changed Section headers to use `#`, `##`, etc.
+ Removed HTML
+ Replace things with Markdown lists
+ Use inline code and code blocks

**Note:** I don't how the [Zabbix Share](https://share.zabbix.com/cat-app/backup/veeam-backup-recovery-jobs-trapper) site will look if these changes are implemented. If they don't support markdown then you might not want to merge this.