### PR TITLE
Autoconfiguration setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Why? Because the execution of this command can take between 30 seconds and more 
   - Result of each jobs
   - Execution status for each jobs
   - Next run time of each jobs
-  
+
 ### 5. Veeam Jobs Replication Backup:
   - Result of each jobs
   - Execution status for each jobs
@@ -111,6 +111,14 @@ Why? Because the execution of this command can take between 30 seconds and more 
 
 
 ## Setup
+
+### Automatic scripted installation
+Run Setup.ps1 for installing the monitoring script on hosts.
+
+### Manual installation
+
+Your host must have PowerShell 3.0 or above. Install upgrade from [Microsoft Download](https://www.microsoft.com/en-us/download/details.aspx?id=34595) for
+windows 7 and Windows 2008.
 
 1. Install the Zabbix agent on your host
 2. Copy `zabbix_vbr_job.ps1` in the directory : `C:\Program Files\Zabbix Agent\scripts\` (create folder if not exist)

--- a/Setup.ps1
+++ b/Setup.ps1
@@ -73,4 +73,10 @@ UserParameter=vbr[*],powershell -NoProfile -ExecutionPolicy Bypass -File ""${zab
     Restart-Zabbix
 }
 
-Setup-VeeamAgent
+# Run as administrator
+$loop = [string]$args[0]
+if ([bool](([System.Security.Principal.WindowsIdentity]::GetCurrent()).groups -match "S-1-5-32-544")) {
+    Setup-VeeamAgent
+} elseif ($loop -eq "") {
+    Start-Process Powershell -Verb runAs -ArgumentList "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`" NoLoop"
+}

--- a/Setup.ps1
+++ b/Setup.ps1
@@ -1,0 +1,76 @@
+function Restart-Zabbix {
+    $Zabbix_Service = Get-Service -Name 'Zabbix Agent' -ErrorAction SilentlyContinue
+    if ($Zabbix_Service -ne $null -and $Zabbix_Service.Status -eq 'Running') {
+        $Zabbix_Service.Stop()
+        $Zabbix_Service.WaitForStatus('Stopped')
+        $Zabbix_Service.Start()
+    }
+}
+
+function Get-ZabbixAgent {
+    $service_config = Get-Item 'HKLM:\SYSTEM\CurrentControlSet\Services\Zabbix Agent' -ErrorAction SilentlyContinue
+    if ($service_config -ne $null) {
+        $image_path = $service_config.GetValue('ImagePath')
+        if ($image_path -match "^`"([^`"]*)`".*$") {
+            return $Matches.1
+        }
+        return $image_path -replace "--config .*", ""
+    }
+
+    throw 'Zabbix not installed'
+}
+
+function Get-ZabbixPath {
+    $install_x64 = Get-Item 'HKLM:\SOFTWARE\Zabbix SIA\Zabbix Agent (64-bit)' -ErrorAction SilentlyContinue
+    if ($install_x64 -ne $null) {
+        return $install_x64.GetValue('InstallFolder')
+    }
+
+    $install_x86 = Get-Item 'HKLM:\SOFTWARE\Zabbix SIA\Zabbix Agent' -ErrorAction SilentlyContinue
+    if ($install_x86 -ne $null) {
+        return $install_x86.GetValue('InstallFolder')
+    }
+
+    return (Get-ChildItem -Path (Get-ZabbixAgent)).DirectoryName
+}
+
+function Setup-VeeamAgent {
+    param(
+        [string]$zabbix_path = (Get-ZabbixPath)
+    )
+
+    $wmi_product = Get-WmiObject -Class Win32_Product -Filter 'Name = "Veeam Backup & Replication Server"'
+    if ($wmi_product -eq $null) {
+        Write-Debug 'Veeam server not installed. Skip.'
+        return
+    }
+
+    $zabbix_config = "
+EnableRemoteCommands=1
+UnsafeUserParameters=1
+Alias=service.discovery.veeam:service.discovery
+Timeout=30
+UserParameter=vbr[*],powershell -NoProfile -ExecutionPolicy Bypass -File ""${zabbix_path}scripts\zabbix_vbr_job.ps1"" ""`$1"" ""`$2"" ""`$3""
+    " -replace "`r`n", "`n"
+
+    #$Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+    #[System.IO.File]::WriteAllLines($zabbix_path + 'zabbix_agentd.conf.d\veeam_agent.conf', $zabbix_config, $Utf8NoBomEncoding)
+    Set-Content -Path ($zabbix_path + 'zabbix_agentd.conf.d\veeam_agent.conf') -Value $zabbix_config -Encoding Ascii
+
+    $script_directory = $zabbix_path + 'scripts'
+    if (-not (Test-Path -Path $script_directory)) {
+        New-Item -ItemType Directory -Path $script_directory
+    }
+
+    $client = new-object System.Net.WebClient
+    $download_path = [System.IO.Path]::GetTempFileName()
+    $client.DownloadFile('https://raw.githubusercontent.com/bontiv/zabbix-VEEAM_B-R/master/zabbix_vbr_job.ps1', $download_path)
+
+    $script_content = Get-Content -Path $download_path
+    Set-Content -Path ($zabbix_path + 'scripts\zabbix_vbr_job.ps1') -Value ($script_content -replace "pathxml = 'C:\\Program Files\\Zabbix Agent\\scripts\\TempXmlVeeam'", "pathxml = '${zabbix_path}scripts\TempXmlVeeam'")
+    Remove-Item -Path $download_path
+
+    Restart-Zabbix
+}
+
+Setup-VeeamAgent

--- a/Template EN/TemplateVEEAM-BACKUP-eng.xml
+++ b/Template EN/TemplateVEEAM-BACKUP-eng.xml
@@ -191,7 +191,7 @@
                     <type>0</type>
                     <snmp_community/>
                     <snmp_oid/>
-                    <key>service.discovery</key>
+                    <key>service.discovery.veeam</key>
                     <delay>3600</delay>
                     <status>0</status>
                     <allowed_hosts/>

--- a/Template FR/Zabbix-V4.X-only-TemplateVEEAM-BACKUP-FR.xml
+++ b/Template FR/Zabbix-V4.X-only-TemplateVEEAM-BACKUP-FR.xml
@@ -106,7 +106,7 @@
             <discovery_rules>
                 <discovery_rule>
                     <name>VEEAM Services</name>
-                    <key>service.discovery</key>
+                    <key>service.discovery.veeam</key>
                     <delay>1h</delay>
                     <filter>
                         <conditions>


### PR DESCRIPTION
Hi,

I created a setup script to auto-configure agents on hosts. It work fine with Windows Windows 8 / Server 2012 and above. For Windows 7 and 2008, I've a little issue with auto elevate as administrator but work if the script is lunched as admin.

I also changed the service discovery in template. In the setup instruction of Readme, you require the user to add an alias. So you can safely use the alias on templates and not having trouble with OS Template.

Best regards,
Rémi